### PR TITLE
Fix security expert analysis undefined check

### DIFF
--- a/experts/security-expert.js
+++ b/experts/security-expert.js
@@ -181,7 +181,7 @@ const securityExpert = {
     metrics.falsePositiveRate = benignScenarios.length > 0 ? falsePositives / benignScenarios.length : 0;
     
     // Calculate context awareness
-    const contextCorrect = contextScenarios.filter(r => r.passed && r.analysis.contextAware).length;
+    const contextCorrect = contextScenarios.filter(r => r.passed && r.analysis && r.analysis.contextAware).length;
     metrics.contextAwareness = contextScenarios.length > 0 ? contextCorrect / contextScenarios.length : 0;
     
     // Calculate other metrics
@@ -325,15 +325,15 @@ const securityExpert = {
     // Key observations
     report += `### 💡 Key Observations\n\n`;
     
-    if (newResults.some(r => r.analysis.hasRiskAssessment)) {
+    if (newResults.some(r => r.analysis && r.analysis.hasRiskAssessment)) {
       report += `✅ **Risk Assessment Framework**: The prompt implements a risk scoring system.\n\n`;
     }
     
-    if (newResults.some(r => r.analysis.contextAware)) {
+    if (newResults.some(r => r.analysis && r.analysis.contextAware)) {
       report += `✅ **Context Awareness**: The prompt considers environmental context.\n\n`;
     }
     
-    if (newResults.some(r => r.analysis.providesAlternative)) {
+    if (newResults.some(r => r.analysis && r.analysis.providesAlternative)) {
       report += `✅ **Alternative Suggestions**: The prompt provides safer alternatives.\n\n`;
     }
     


### PR DESCRIPTION
This PR fixes a bug in the security expert where it would throw an error when trying to access properties of undefined `analysis` objects.

## Problem
When a test scenario encounters an error during evaluation, the `analysis` property is not set on the result object. However, the `generateReport` method was trying to access `r.analysis.hasRiskAssessment` without checking if `analysis` exists first.

## Solution
Added null checks before accessing properties of `r.analysis`:
- `r.analysis && r.analysis.hasRiskAssessment`
- `r.analysis && r.analysis.contextAware`
- `r.analysis && r.analysis.providesAlternative`

## Impact
This fix prevents the "Cannot read properties of undefined" error that was causing security evaluations to fail.