### PR TITLE
Add auto-close functionality for failed PR evaluations

### DIFF
--- a/.github/workflows/evaluate-prompts.yml
+++ b/.github/workflows/evaluate-prompts.yml
@@ -9,6 +9,11 @@ on:
       repository:
         required: true
         type: string
+      auto-close-on-fail:
+        required: false
+        type: boolean
+        default: true
+        description: 'Automatically close PR if evaluation fails'
     secrets:
       github-token:
         required: true
@@ -198,6 +203,25 @@ jobs:
                 body: fullReport
               });
               
+              // Auto-close PR if not approved and auto-close is enabled
+              const autoCloseOnFail = process.env.AUTO_CLOSE_ON_FAIL !== 'false';
+              if (overallRecommendation !== 'APPROVE' && autoCloseOnFail) {
+                console.log('Closing PR due to failed evaluation...');
+                await octokit.pulls.update({
+                  owner: OWNER,
+                  repo: REPO,
+                  pull_number: PR_NUMBER,
+                  state: 'closed'
+                });
+                
+                await octokit.issues.createComment({
+                  owner: OWNER,
+                  repo: REPO,
+                  issue_number: PR_NUMBER,
+                  body: `🚫 **PR automatically closed** due to failed security evaluation.\n\nPlease address the feedback above and submit a new PR with the improvements.`
+                });
+              }
+              
               console.log('Evaluation completed successfully');
               
             } catch (error) {
@@ -237,4 +261,4 @@ jobs:
           EOF
           
           # Run evaluation
-          OWNER="${OWNER}" REPO="${REPO}" PR_NUMBER="${{ inputs.pr-number }}" GITHUB_BASE_REF="${{ github.base_ref }}" node evaluate.js
+          OWNER="${OWNER}" REPO="${REPO}" PR_NUMBER="${{ inputs.pr-number }}" GITHUB_BASE_REF="${{ github.base_ref }}" AUTO_CLOSE_ON_FAIL="${{ inputs.auto-close-on-fail }}" node evaluate.js


### PR DESCRIPTION
This PR adds the ability to automatically close PRs that fail expert evaluation.

## Features Added

- **Configurable auto-close**: New `auto-close-on-fail` workflow input (default: true)
- **Automatic PR closure**: PRs receiving REQUEST_CHANGES are automatically closed
- **Clear communication**: Adds explanatory comment when closing PRs
- **Opt-out capability**: Repositories can disable auto-close by setting parameter to false

## Why This Change?

- Maintains PR hygiene by preventing failed PRs from lingering
- Forces submitters to create fresh PRs with improvements
- Makes the evaluation system more decisive and actionable
- Reduces manual work of closing failed PRs

## How It Works

1. Expert evaluates the PR and determines recommendation
2. If recommendation is REQUEST_CHANGES and auto-close is enabled:
   - Posts evaluation report comment
   - Closes the PR with explanatory message
   - Instructs user to submit new PR with improvements

## Usage

In your workflow:
```yaml
uses: whichguy/prompt-expert-bank/.github/workflows/evaluate-prompts.yml@main
with:
  pr-number: ${{ github.event.pull_request.number }}
  repository: ${{ github.repository }}
  auto-close-on-fail: true  # Optional, defaults to true
```